### PR TITLE
Retrieve correct username

### DIFF
--- a/menotexport.py
+++ b/menotexport.py
@@ -147,7 +147,7 @@ def getUserName(db):
 
     query=\
     '''SELECT Profiles.firstName, Profiles.lastName
-    FROM Profiles
+    FROM Profiles WHERE Profiles.isSelf="true"
     '''
     ret=db.execute(query)
     ret=[ii for ii in ret]


### PR DESCRIPTION
Make sure that the username corresponds to the profile with `isSelf = "true"`.

----

Again, not an SQL expert so maybe it's not the correct or smarter way to do that. As already briefly discussed in https://github.com/Xunius/Menotexport/pull/27, the result I want to get is that the username is the one, among all the profiles listed in the table, that has the attribute `isSelf = "true"`.

I attach below a screenshot of the corresponding table in my database:
![screenshot from 2018-07-21 19-30-50 - redacted](https://user-images.githubusercontent.com/4618521/43038831-3b5a3696-8d21-11e8-8d60-764715d45056.png)

From my tests so far, this small edit seems to work.